### PR TITLE
Implement SetConsoleCursorPosition

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -57,6 +57,12 @@ impl ScreenBuffer {
         if res == 0 { return last_error() }
         Ok(())
     }
+    pub fn set_cursor_position(&self, pos: (i16, i16)) -> Result<()> {
+        let pos = w::COORD { X: pos.0, Y: pos.1 };
+        let res = unsafe { k32::SetConsoleCursorPosition(*self.0, pos) };
+        if res == 0 { return last_error() }
+        Ok(())
+    }
 }
 impl FromRawHandle for ScreenBuffer {
     unsafe fn from_raw_handle(handle: w::HANDLE) -> ScreenBuffer {

--- a/src/console.rs
+++ b/src/console.rs
@@ -74,6 +74,7 @@ impl ScreenBuffer {
         let res = unsafe { k32::SetConsoleCursorPosition(*self.0, pos) };
         if res == 0 { return last_error() }
         Ok(())
+    }
     pub fn font_size(&self) -> Result<(i16, i16)> {
         unsafe {
             let mut font = zeroed();


### PR DESCRIPTION
Provide a wrapper for SetConsoleCursorPosition as ScreenBuffer::set_cursor_position.
