### PR TITLE
Fix build for stable by removing feature flag

### DIFF
--- a/src/com.rs
+++ b/src/com.rs
@@ -40,7 +40,7 @@ impl<T> DerefMut for ComPtr<T> {
 }
 impl<T> Clone for ComPtr<T> {
     fn clone(&self) -> Self {
-        unsafe { 
+        unsafe {
             self.as_unknown().AddRef();
             ComPtr::new(self.0)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright © 2016, Peter Atashian
 // Licensed under the MIT License <LICENSE.md>
 #![cfg(windows)]
-#![feature(const_fn)]
 extern crate winapi as w;
 extern crate kernel32 as k32;
 


### PR DESCRIPTION
Remove `const_fn` feature as it doesn't seems to be used and blocks compilation on stable channel.