### PR TITLE
ComPtr(NonNull<T>)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["windows", "ffi", "win32", "com"]
 categories = ["api-bindings", "os::windows-apis"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE-MIT", "/LICENSE-APACHE", "/build.rs", "/README.md"]
 
+[features]
+com_nonnull = []
+
 [dependencies]
 winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "unknwnbase"] }
 

--- a/src/com.rs
+++ b/src/com.rs
@@ -12,28 +12,24 @@ use std::ptr::NonNull;
 use winapi::Interface;
 use winapi::um::unknwnbase::IUnknown;
 
-#[cfg(not(feature = "com_nonnull"))]
+
 /// ComPtr to wrap COM interfaces sanely
-pub struct ComPtr<T>(*mut T) where T: Interface;
-#[cfg(feature = "com_nonnull")]
-/// ComPtr to wrap COM interfaces sanely
-pub struct ComPtr<T>(NonNull<T>) where T: Interface;
+pub struct ComPtr<T>(
+    #[cfg(not(feature = "com_nonnull"))] *mut T,
+    #[cfg(feature = "com_nonnull")] NonNull<T>,
+) where T: Interface;
 impl<T> ComPtr<T> where T: Interface {
     /// Creates a `ComPtr` to wrap a raw pointer.
     /// It takes ownership over the pointer which means it does __not__ call `AddRef`.
     /// `T` __must__ be a COM interface that inherits from `IUnknown`.
-    #[cfg(not(feature = "com_nonnull"))]
     pub unsafe fn from_raw(ptr: *mut T) -> ComPtr<T> {
         assert!(!ptr.is_null());
-        ComPtr(ptr)
-    }
-    /// Creates a `ComPtr` to wrap a raw pointer.
-    /// It takes ownership over the pointer which means it does __not__ call `AddRef`.
-    /// `T` __must__ be a COM interface that inherits from `IUnknown`.
-    #[cfg(feature = "com_nonnull")]
-    pub unsafe fn from_raw(ptr: *mut T) -> ComPtr<T> {
-        assert!(!ptr.is_null());
-        ComPtr(NonNull::new_unchecked(ptr))
+        #[cfg(not(feature = "com_nonnull"))] {
+            ComPtr(ptr)
+        }
+        #[cfg(feature = "com_nonnull")] {
+            ComPtr(NonNull::new_unchecked(ptr))
+        }
     }
     /// Casts up the inheritance chain
     pub fn up<U>(self) -> ComPtr<U> where T: Deref<Target=U>, U: Interface {
@@ -59,15 +55,13 @@ impl<T> ComPtr<T> where T: Interface {
     }
     /// Obtains the raw pointer without transferring ownership.
     /// Do __not__ release this pointer because it is still owned by the `ComPtr`.
-    #[cfg(not(feature = "com_nonnull"))]
     pub fn as_raw(&self) -> *mut T {
-        self.0
-    }
-    /// Obtains the raw pointer without transferring ownership.
-    /// Do __not__ release this pointer because it is still owned by the `ComPtr`.
-    #[cfg(feature = "com_nonnull")]
-    pub fn as_raw(&self) -> *mut T {
-        self.0.as_ptr()
+        #[cfg(not(feature = "com_nonnull"))] {
+            self.0
+        }
+        #[cfg(feature = "com_nonnull")] {
+            self.0.as_ptr()
+        }
     }
 }
 impl<T> Deref for ComPtr<T> where T: Interface {

--- a/src/com.rs
+++ b/src/com.rs
@@ -12,10 +12,11 @@ use std::ptr::NonNull;
 use winapi::Interface;
 use winapi::um::unknwnbase::IUnknown;
 
-/// ComPtr to wrap COM interfaces sanely
 #[cfg(not(feature = "com_nonnull"))]
+/// ComPtr to wrap COM interfaces sanely
 pub struct ComPtr<T>(*mut T) where T: Interface;
 #[cfg(feature = "com_nonnull")]
+/// ComPtr to wrap COM interfaces sanely
 pub struct ComPtr<T>(NonNull<T>) where T: Interface;
 impl<T> ComPtr<T> where T: Interface {
     /// Creates a `ComPtr` to wrap a raw pointer.

--- a/src/com.rs
+++ b/src/com.rs
@@ -12,7 +12,6 @@ use std::ptr::NonNull;
 use winapi::Interface;
 use winapi::um::unknwnbase::IUnknown;
 
-
 /// ComPtr to wrap COM interfaces sanely
 pub struct ComPtr<T>(
     #[cfg(not(feature = "com_nonnull"))] *mut T,


### PR DESCRIPTION
Optional feature which allows ComPtr to use NonNull when using newer versions of rustc (1.25 stable or later), giving the nonzero enum value optimization to Option<ComPtr<T>>