### PR TITLE
Make ComPtr be repr(transparent) and NonNull

### DIFF
--- a/src/com.rs
+++ b/src/com.rs
@@ -6,34 +6,34 @@
 // except according to those terms.
 use std::mem::forget;
 use std::ops::Deref;
-use std::ptr::null_mut;
+use std::ptr::{NonNull, null_mut};
 use winapi::Interface;
 use winapi::um::unknwnbase::IUnknown;
 
 // ComPtr to wrap COM interfaces sanely
-pub struct ComPtr<T>(*mut T) where T: Interface;
+#[repr(transparent)]
+pub struct ComPtr<T>(NonNull<T>) where T: Interface;
 impl<T> ComPtr<T> where T: Interface {
     /// Creates a `ComPtr` to wrap a raw pointer.
     /// It takes ownership over the pointer which means it does __not__ call `AddRef`.
     /// `T` __must__ be a COM interface that inherits from `IUnknown`.
     pub unsafe fn from_raw(ptr: *mut T) -> ComPtr<T> {
-        assert!(!ptr.is_null());
-        ComPtr(ptr)
+        ComPtr(NonNull::new(ptr).expect("ptr should not be null"))
     }
     /// Casts up the inheritance chain
     pub fn up<U>(self) -> ComPtr<U> where T: Deref<Target=U>, U: Interface {
-        ComPtr(self.into_raw() as *mut U)
+        unsafe { ComPtr::from_raw(self.into_raw() as *mut U) }
     }
     /// Extracts the raw pointer.
     /// You are now responsible for releasing it yourself.
     pub fn into_raw(self) -> *mut T {
-        let p = self.0;
+        let p = self.0.as_ptr();
         forget(self);
         p
     }
     /// For internal use only.
     fn as_unknown(&self) -> &IUnknown {
-        unsafe { &*(self.0 as *mut IUnknown) }
+        unsafe { &*(self.as_raw() as *mut IUnknown) }
     }
     /// Performs QueryInterface fun.
     pub fn cast<U>(&self) -> Result<ComPtr<U>, i32> where U: Interface {
@@ -45,20 +45,20 @@ impl<T> ComPtr<T> where T: Interface {
     /// Obtains the raw pointer without transferring ownership.
     /// Do __not__ release this pointer because it is still owned by the `ComPtr`.
     pub fn as_raw(&self) -> *mut T {
-        self.0
+        self.0.as_ptr()
     }
 }
 impl<T> Deref for ComPtr<T> where T: Interface {
     type Target = T;
     fn deref(&self) -> &T {
-        unsafe { &*self.0 }
+        unsafe { &*self.as_raw() }
     }
 }
 impl<T> Clone for ComPtr<T> where T: Interface {
     fn clone(&self) -> Self {
         unsafe {
             self.as_unknown().AddRef();
-            ComPtr::from_raw(self.0)
+            ComPtr::from_raw(self.as_raw())
         }
     }
 }


### PR DESCRIPTION
This will make wio require 1.25 stable to build, but I never got a clear answer from you on if that's acceptable I don't think