### PR TITLE
Add Error::system_message, and some other improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,25 @@ categories = ["api-bindings", "os::windows-apis"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE-MIT", "/LICENSE-APACHE", "/build.rs", "/README.md"]
 
 [dependencies]
-winapi = { version = "0.3", features = [
-    "consoleapi", "errhandlingapi", "fileapi", "handleapi", "minwindef", "processthreadsapi", "std", "unknwnbase", "wincon", "winnt",
-] }
+libc = "0.2"
+
+[dependencies.winapi]
+version = "0.3"
+features = [
+    "consoleapi",
+    "errhandlingapi",
+    "fileapi",
+    "handleapi",
+    "minwindef",
+    "processthreadsapi",
+    "std",
+    "unknwnbase",
+    "winbase",
+    "wincon",
+    "winerror",
+    "winuser",
+    "winnt",
+]
 
 [dev-dependencies]
 rand = "0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,6 @@ use std::result;
 use std::slice;
 use std::os::windows::ffi::OsStringExt;
 use winapi::shared::minwindef::DWORD;
-use winapi::shared::winerror::SUCCEEDED;
 use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::winbase::{self, FormatMessageW};
 use winapi::um::winnt::{self, MAKELANGID, WCHAR};

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,16 +3,80 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
+
+use libc::wcslen;
+use std::error::Error as StdError;
+use std::fmt;
+use std::ffi::OsString;
+use std::ptr;
 use std::result;
+use std::slice;
+use std::os::windows::ffi::OsStringExt;
 use winapi::shared::minwindef::DWORD;
+use winapi::shared::winerror::SUCCEEDED;
 use winapi::um::errhandlingapi::GetLastError;
-#[derive(Clone, Copy, Debug)]
+use winapi::um::winbase::{self, FormatMessageW};
+use winapi::um::winnt::{self, MAKELANGID, WCHAR};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Error(DWORD);
+
 impl Error {
-    pub fn code(&self) -> u32 { self.0 }
+    pub fn code(&self) -> u32 {
+        self.0
+    }
+
     pub fn last<T>() -> Result<T> {
         Err(Error(unsafe { GetLastError() }))
     }
+
+    #[must_use]
+    pub fn system_message(&self) -> OsString {
+        unsafe {
+            let mut error_text: *mut WCHAR = ptr::null_mut();
+
+            FormatMessageW(
+                winbase::FORMAT_MESSAGE_FROM_SYSTEM
+                    | winbase::FORMAT_MESSAGE_ALLOCATE_BUFFER
+                    | winbase::FORMAT_MESSAGE_IGNORE_INSERTS,
+                ptr::null_mut(),
+                self.code() as _,
+                MAKELANGID(winnt::LANG_NEUTRAL, winnt::SUBLANG_DEFAULT) as _,
+                &mut error_text as *mut _ as *mut _,
+                0,
+                ptr::null_mut(),
+            );
+
+            let wchars = if !error_text.is_null() {
+                slice::from_raw_parts(error_text, wcslen(error_text))
+            } else {
+                &[]
+            };
+
+            let message = OsString::from_wide(wchars);
+
+            if !error_text.is_null() {
+                winbase::LocalFree(error_text as *mut _);
+            }
+
+            message
+        }
+    }
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = self.system_message().into_string().ok();
+        f.pad(desc.as_ref().map(String::as_str).unwrap_or("Unknown error"))
+    }
+}
+
+impl Into<u32> for Error {
+    fn into(self) -> u32 {
+        self.code()
+    }
+}
+
+impl StdError for Error {}
 
 pub type Result<T> = result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
+
 #![cfg(windows)]
 extern crate winapi;
+extern crate libc;
 
 // pub mod apc;
 pub mod com;


### PR DESCRIPTION
Provide a wrapper to retreive the error message for a specific error code from the operating system. Allows implementing `Display` for `Error`, which in turn allows implementing `std::error::Error` for `Error`. Also add an `Into<u32>` impl for `Error`.