### PR TITLE
Fix technical undefined behavior

### DIFF
--- a/src/com.rs
+++ b/src/com.rs
@@ -69,7 +69,11 @@ impl<T> Debug for ComPtr<T> {
 }
 impl<T> Drop for ComPtr<T> {
     fn drop(&mut self) {
-        unsafe { self.as_unknown().Release(); }
+        unsafe {
+            let ptr = self.as_raw() as *mut IUnknown;
+            let release_fn = (*(*ptr).lpVtbl).Release;
+            release_fn(ptr);
+        }
     }
 }
 impl<T> PartialEq<ComPtr<T>> for ComPtr<T> where T: Interface {


### PR DESCRIPTION
I believe that the current drop implementation has technical undefined behavior, because holds a reference to the `IUnknown` object while that object is in the process of being deallocated. This patch retrieves the function pointer, drops the reference, then does the release.