### PR TITLE
Add default-target = "x86_64-pc-windows-msvc" key to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ keywords = ["windows", "ffi", "win32", "com"]
 categories = ["api-bindings", "os::windows-apis"]
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE-MIT", "/LICENSE-APACHE", "/build.rs", "/README.md"]
 
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+
 [dependencies]
 winapi = { version = "0.3", features = [
     "consoleapi", "errhandlingapi", "fileapi", "handleapi", "minwinbase", "minwindef", "processthreadsapi", "std", "synchapi", "unknwnbase", "winbase", "wincon", "winerror", "winnt",
 ] }
 log = { version = "0.4", optional = true }
-
-[package.metadata.docs.rs]
-default-target = "x86_64-pc-windows-msvc"
 
 [dev-dependencies]
 rand = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,8 @@ winapi = { version = "0.3", features = [
 ] }
 log = { version = "0.4", optional = true }
 
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+
 [dev-dependencies]
 rand = "0.4"


### PR DESCRIPTION
This fixes #19.