### PR TITLE
Add ComPtr::new_class

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ targets = [
 [dependencies]
 log = { version = "0.4", optional = true }
 winapi = { version = "0.3", features = [
+    "combaseapi",
     "consoleapi",
     "errhandlingapi",
     "fileapi",


### PR DESCRIPTION
Adds a type-based convenience function to `ComPtr` for creating instances of a COM class. This is a relatively common pattern, so I think it's worth exposing through `wio`'s API.