### PR TITLE
Improve from_fn and add com_ptr_from_fn macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ winapi = { version = "0.3", features = [
     "mmdeviceapi",
     "processthreadsapi",
     "setupapi",
+    "shobjidl_core",
     "std",
     "synchapi",
     "unknwnbase",

--- a/src/com.rs
+++ b/src/com.rs
@@ -12,20 +12,6 @@ use winapi::shared::guiddef::GUID;
 use winapi::shared::winerror::HRESULT;
 use winapi::Interface;
 
-#[doc(hidden)]
-#[macro_export]
-#[cfg(feature = "log")]
-macro_rules! log_if_feature {
-    ($($args:tt)*) => {log::warn!($($args)*)};
-}
-
-#[doc(hidden)]
-#[macro_export]
-#[cfg(not(feature = "log"))]
-macro_rules! log_if_feature {
-    ($($args:tt)*) => {};
-}
-
 /// Simplifies the common pattern of calling a function to initialize multiple `ComPtr`s.
 ///
 /// This macro is a generalization of [`ComPtr::from_fn`][from_fn] to functions

--- a/src/com.rs
+++ b/src/com.rs
@@ -118,7 +118,7 @@ impl<T> ComPtr<T> {
     ///
     /// If you're calling a COM function that generates multiple COM objects, use the
     /// [`com_ptr_from_fn!`](../macro.com_ptr_from_fn.html) macro.
-    pub unsafe fn from_fn<F, E>(fun: F) -> Result<ComPtr<T>, HRESULT>
+    pub unsafe fn from_fn<F>(fun: F) -> Result<ComPtr<T>, HRESULT>
     where
         T: Interface,
         F: FnOnce(&GUID, &mut *mut c_void) -> HRESULT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,20 @@
 #![allow(clippy::missing_safety_doc, clippy::len_without_is_empty)]
 extern crate winapi;
 
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "log")]
+macro_rules! log_if_feature {
+    ($($args:tt)*) => {log::warn!($($args)*)};
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "log"))]
+macro_rules! log_if_feature {
+    ($($args:tt)*) => {};
+}
+
 // pub mod apc;
 pub mod bstr;
 pub mod com;

--- a/tests/com_ptr_from_fn.rs
+++ b/tests/com_ptr_from_fn.rs
@@ -1,0 +1,39 @@
+extern crate wio;
+extern crate winapi;
+
+use wio::{com_ptr_from_fn, com::ComPtr};
+use winapi::{
+    Class,
+    um::{
+        combaseapi,
+        shobjidl_core::{ShellItem, TaskbarList, IShellItem, ITaskbarList},
+    },
+};
+use std::ptr::null_mut;
+
+#[test]
+fn test_multi_com_ptr() {
+    unsafe {
+        let _: Result<(ComPtr<IShellItem>, ComPtr<ITaskbarList>), _> = com_ptr_from_fn!(
+            |(shell_guid, shell_ptr), (taskbar_guid, taskbar_ptr)| {
+                let hr = combaseapi::CoCreateInstance(
+                    &ShellItem::uuidof(),
+                    null_mut(),
+                    combaseapi::CLSCTX_ALL,
+                    shell_guid,
+                    shell_ptr,
+                );
+                if hr != 0 {
+                    return hr;
+                }
+                combaseapi::CoCreateInstance(
+                    &TaskbarList::uuidof(),
+                    null_mut(),
+                    combaseapi::CLSCTX_ALL,
+                    taskbar_guid,
+                    taskbar_ptr,
+                )
+            }
+        );
+    }
+}

--- a/tests/com_ptr_from_fn.rs
+++ b/tests/com_ptr_from_fn.rs
@@ -1,3 +1,9 @@
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// All files in the project carrying such notice may not be copied, modified, or distributed
+// except according to those terms.
+
 extern crate wio;
 extern crate winapi;
 


### PR DESCRIPTION
This PR implements the suggestions I made for `from_fn` in the Rust Community Discord, with some further iterations. Namely:
- `from_fn` returns `Result<ComPtr<T>, HRESULT>` instead of `Result<Option<ComPtr<T>>, E>`
- `F` is redefined as `FnOnce(&GUID, &mut *mut P) -> HRESULT`

It also adds a `com_ptr_from_fn` function that generalizes `from_fn` for COM functions that output multiple COM objects (such as [`ICallFactory::CreateCall`](https://docs.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-icallfactory-createcall)). 