### PR TITLE
Add `docs.rs` metadata like that of upstream `winapi`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ include = [
     "/README.md",
 ]
 
+[package.metadata.docs.rs]
+features = ["everything", "impl-debug", "impl-default"]
+default-target = "x86_64-pc-windows-msvc"
+targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
+
 [dependencies]
 log = { version = "0.4", optional = true }
 winapi = { version = "0.3", features = [


### PR DESCRIPTION
This allows for a nicer experiences at https://docs.rs/wio (which right now shows no symbols):

![image](https://user-images.githubusercontent.com/658538/90807231-65b07600-e2db-11ea-9b63-5b66d6185619.png)

...so that, like https://docs.rs/winapi, there's actually something to see as intended:

![image](https://user-images.githubusercontent.com/658538/90807339-92648d80-e2db-11ea-82f4-b18facc79ae2.png)